### PR TITLE
add `fields` to place details query

### DIFF
--- a/src/services/google.service.ts
+++ b/src/services/google.service.ts
@@ -137,7 +137,7 @@ export class GoogleService {
 
   public static async searchDetails(
     placeid: string,
-    query: Query
+    query: Query & { fields?: string }
   ): Promise<GoogleLocationDetailResult> {
     const url = `${BASE_URL}/details/json?${queryString.stringify({
       ...normalizeQuery(query),


### PR DESCRIPTION
Place details query should have a `fields` parameter.

Available options for GooglePlacesDetails API: https://developers.google.com/maps/documentation/places/web-service/details#optional-parameters