### PR TITLE
fix: use proxyUrl for details

### DIFF
--- a/src/GoogleAutocomplete.tsx
+++ b/src/GoogleAutocomplete.tsx
@@ -128,12 +128,20 @@ export const useGoogleAutocomplete = (apiKey: string, opts: Options = {}) => {
   };
 
   const searchDetails = async (placeId: string) => {
-    return GoogleService.searchDetails(placeId, {
-      key: apiKey,
-      language,
-      types: queryTypes,
-      components: opts.components,
-    });
+    if (isWeb && !opts.proxyUrl) {
+      throw new Error('A proxy url is needed for web');
+    }
+
+    return GoogleService.searchDetails(
+      placeId,
+      {
+        key: apiKey,
+        language,
+        types: queryTypes,
+        components: opts.components,
+      },
+      opts.proxyUrl
+    );
   };
 
   const clearSearch = () => {

--- a/src/services/google.service.ts
+++ b/src/services/google.service.ts
@@ -137,14 +137,17 @@ export class GoogleService {
 
   public static async searchDetails(
     placeid: string,
-    query: Query & { fields?: string }
+    query: Query & { fields?: string },
+    proxyUrl?: string
   ): Promise<GoogleLocationDetailResult> {
     const url = `${BASE_URL}/details/json?${queryString.stringify({
       ...normalizeQuery(query),
       placeid,
     })}`;
 
-    const res = await fetch(url);
+    const _url = proxyUrl ? proxyUrl + url : url;
+
+    const res = await fetch(_url);
 
     const resJson: {
       status: string;


### PR DESCRIPTION
ProxyUrl only works on the search, but not for fetching details. This PR fixes that